### PR TITLE
Bug Fix : Scrollbar issue in Geometric Art by Shamli iframe

### DIFF
--- a/arts/geometry.html
+++ b/arts/geometry.html
@@ -11,6 +11,7 @@
       justify-content: center;
       align-items: center;
       background: #f0f8ff;
+      overflow: hidden;
     }
 
     .geometric-art {

--- a/arts/rotating_cube.html
+++ b/arts/rotating_cube.html
@@ -12,6 +12,7 @@
       display: flex;
       justify-content: center;
       align-items: center;
+      overflow: hidden;
     }
     .scene {
       width: 200px;

--- a/style.css
+++ b/style.css
@@ -44,6 +44,7 @@ header p {
   background-color: #fff;
   border-radius: 12px;
   padding: 10px;
+  
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   transition: transform 0.3s, box-shadow 0.3s;
 }
@@ -51,6 +52,19 @@ header p {
 .art-card:hover {
   transform: translateY(-5px);
   box-shadow: 0 8px 20px rgba(0,0,0,0.2);
+}
+
+.art-card iframe {
+  width: 100%;
+  height: 300px;
+  border: none;
+  border-radius: 8px;
+  overflow: hidden;   
+  scrollbar-width: none;
+}
+
+.art-card iframe::-webkit-scrollbar {
+  display: none; 
 }
 
 .art-card iframe {


### PR DESCRIPTION
**Description:**
This PR fixes the unwanted scrollbars that were appearing inside the Geometric Art by Shamli ```(arts/geometry.html)``` iframe in the gallery.

**Changes Made:**
Updated ```arts/geometry.html``` to hide overflow and remove scrollbars.
```
body {
  margin: 0;
  height: 100vh;
  display: flex;
  justify-content: center;
  align-items: center;
  background: #f0f8ff;
  overflow: hidden; 
}
```
Screenshots related to this : 
<img width="1919" height="870" alt="Screenshot 2025-10-02 203412" src="https://github.com/user-attachments/assets/df6bbfc3-2531-4bbe-aab4-e6a5ca6d1a33" />

**Before:**
- Scrollbars visible inside the iframe.
- Artwork edges slightly clipped.
**After:**
- No scrollbars inside iframe.
- Artwork centered and displayed cleanly.

closes #15 