### PR TITLE
feat: Add missing preview links to all art cards Fixes #77

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,56 +15,26 @@
     <main class="gallery">
     
       <div class="art-card">
-        <iframe src="arts/hariksh-sunset.html" title="Sunset CSS Art"></iframe>
-        <p>Sample Art by Hariksh</p>
+        <a href="art-viewer.html?file=hariksh-sunset.html">
+          <iframe src="arts/hariksh-sunset.html" title="Sunset CSS Art"></iframe>
+          <p>Sample Art by Hariksh</p>
+          <div class="link">Preview the code</div>
+        </a>
       </div>
       <div class="art-card">
-        <iframe src="arts/sample.html" title="Sample CSS Art"></iframe>
-        <p>Sample Art by Shamli</p>
+        <a href="art-viewer.html?file=sample.html">
+          <iframe src="arts/sample.html" title="Sample CSS Art"></iframe>
+          <p>Sample Art by Shamli</p>
+          <div class="link">Preview the code</div>
+        </a>
       </div>
       <div class="art-card">
-        <iframe src="arts/matrix.html" title="Matrix Rain Animation"></iframe>
-        <p>Sample Art by Eternity</p>
+        <a href="art-viewer.html?file=matrix.html">
+          <iframe src="arts/matrix.html" title="Matrix Rain Animation"></iframe>
+          <p>Sample Art by Eternity</p>
+          <div class="link">Preview the code</div>
+        </a>
       </div>
-      <div class="art-card">
-        <iframe src="arts/geometry.html" title="Geometric CSS Art"></iframe>
-        <p>Geometric Art by Shamli</p>
-      </div>
-      <div class="art-card">
-        <iframe src="arts/rotating_cube.html" title="Rotating Cube"></iframe>
-        <p>Geometric Art by Hardik</p>
-      </div>
-      <div class="art-card">
-        <iframe src="arts/Rohith_stars.html" title="Glowing Star"></iframe>
-        <p>Glowing Star by Rohith</p>
-      </div>
-      <div class="art-card">
-        <iframe src="arts/helicopter.html" title="Helicopter"></iframe>
-        <p>Helicopter by Dhamith</p>
-      </div>
-      <div class="art-card">
-        <iframe src="arts/irfan-goldennight.html" title="Golden Night"></iframe>
-        <p>Golden Night by Irfan</p>
-      </div>
-      <div class="art-card">
-        <iframe src="arts/irfan-ocean.html" title="Ocean Scene"></iframe>
-        <p>Ocean Scene by Irfan</p>
-      </div>
-      <div class="art-card">
-        <iframe src="arts/waqar-cat.html" title="CSS Cat Art"></iframe>
-        <p>Cat by Waqar</p>
-      </div>
-      
-      <div class="art-card">
-        <iframe src="arts/mbm08-ironman.html" title="Ironman CSS Art"></iframe>
-        <p>Ironman by MBM08</p>
-      </div>
-      
-      <div class="art-card">
-        <iframe src="arts/matrix-pulse-loading.html" title="Matrix Pulse Loading"></iframe>
-        <p>Matrix Pulse Loading</p>
-      </div>
-
       <div class="art-card">
         <a href="art-viewer.html?file=geometry.html">
           <iframe src="arts/geometry.html" title="Geometric CSS Art"></iframe>
@@ -72,7 +42,6 @@
           <div class="link">Preview the code</div>
         </a>
       </div>
-
       <div class="art-card">
         <a href="art-viewer.html?file=rotating_cube.html">
           <iframe src="arts/rotating_cube.html" title="Rotating Cube"></iframe>
@@ -80,7 +49,6 @@
           <div class="link">Preview the code</div>
         </a>
       </div>
-
       <div class="art-card">
         <a href="art-viewer.html?file=Rohith_stars.html">
           <iframe src="arts/Rohith_stars.html" title="Glowing Star"></iframe>
@@ -88,7 +56,6 @@
           <div class="link">Preview the code</div>
         </a>
       </div>
-
       <div class="art-card">
         <a href="art-viewer.html?file=helicopter.html">
           <iframe src="arts/helicopter.html" title="Helicopter"></iframe>
@@ -96,27 +63,13 @@
           <div class="link">Preview the code</div>
         </a>
       </div>
-
       <div class="art-card">
-        <iframe src="arts/yash-zoomout.html" title="CSS Owl Art"></iframe>
-        <p>Solar system by Yash</p>
+        <a href="art-viewer.html?file=irfan-goldennight.html">
+          <iframe src="arts/irfan-goldennight.html" title="Golden Night"></iframe>
+          <p>Golden Night by Irfan</p>
+          <div class="link">Preview the code</div>
+        </a>
       </div>
-      
-       <div class="art-card">
-        <iframe src="arts/Dhanush-particle_constellation.html" title="Particle Constellation"></iframe>
-        <p>Particle Constellation by DhanushNehru</p>
-      </div>
-      
-       <div class="art-card">
-        <iframe src="arts/krishna-morphing-hologram.html" title="Morphing Hologram"></iframe>
-        <p>Morphing Hologram by Krishna</p>
-      </div>
-      
-       <div class="art-card">
-        <iframe src="arts/prasanth_bounce.html" title="Bounce"></iframe>
-        <p>Bounce By Prasanth</p>
-      </div>
-
       <div class="art-card">
         <a href="art-viewer.html?file=irfan-ocean.html">
           <iframe src="arts/irfan-ocean.html" title="Ocean Scene"></iframe>
@@ -128,6 +81,54 @@
         <a href="art-viewer.html?file=waqar-cat.html">
           <iframe src="arts/waqar-cat.html" title="CSS Cat Art"></iframe>
           <p>Cat by Waqar</p>
+          <div class="link">Preview the code</div>
+        </a>
+      </div>
+      
+      <div class="art-card">
+        <a href="art-viewer.html?file=mbm08-ironman.html">
+          <iframe src="arts/mbm08-ironman.html" title="Ironman CSS Art"></iframe>
+          <p>Ironman by MBM08</p>
+          <div class="link">Preview the code</div>
+        </a>
+      </div>
+      
+      <div class="art-card">
+        <a href="art-viewer.html?file=matrix-pulse-loading.html">
+          <iframe src="arts/matrix-pulse-loading.html" title="Matrix Pulse Loading"></iframe>
+          <p>Matrix Pulse Loading</p>
+          <div class="link">Preview the code</div>
+        </a>
+      </div>
+
+      <div class="art-card">
+        <a href="art-viewer.html?file=yash-zoomout.html">
+          <iframe src="arts/yash-zoomout.html" title="CSS Owl Art"></iframe>
+          <p>Solar system by Yash</p>
+          <div class="link">Preview the code</div>
+        </a>
+      </div>
+      
+       <div class="art-card">
+        <a href="art-viewer.html?file=Dhanush-particle_constellation.html">
+          <iframe src="arts/Dhanush-particle_constellation.html" title="Particle Constellation"></iframe>
+          <p>Particle Constellation by DhanushNehru</p>
+          <div class="link">Preview the code</div>
+        </a>
+      </div>
+      
+       <div class="art-card">
+        <a href="art-viewer.html?file=krishna-morphing-hologram.html">
+          <iframe src="arts/krishna-morphing-hologram.html" title="Morphing Hologram"></iframe>
+          <p>Morphing Hologram by Krishna</p>
+          <div class="link">Preview the code</div>
+        </a>
+      </div>
+      
+       <div class="art-card">
+        <a href="art-viewer.html?file=prasanth_bounce.html">
+          <iframe src="arts/prasanth_bounce.html" title="Bounce"></iframe>
+          <p>Bounce By Prasanth</p>
           <div class="link">Preview the code</div>
         </a>
       </div>
@@ -144,58 +145,62 @@
       </div>
 
       <div class="art-card">
-        <iframe src="arts/angel-ufo_alien.html" title="Hovering UFO with Alien"></iframe>
-        <p>Hovering UFO by Angel</p>
+        <a href="art-viewer.html?file=angel-ufo_alien.html">
+          <iframe src="arts/angel-ufo_alien.html" title="Hovering UFO with Alien"></iframe>
+          <p>Hovering UFO by Angel</p>
+          <div class="link">Preview the code</div>
+        </a>
       </div>
     
       <div class="art-card">
-        <iframe src="arts/bouncing_ball.html" title="CSS Cat Art"></iframe>
-        <p>Bouncing Ball by Kartikay</p>
+        <a href="art-viewer.html?file=bouncing_ball.html">
+          <iframe src="arts/bouncing_ball.html" title="CSS Cat Art"></iframe>
+          <p>Bouncing Ball by Kartikay</p>
+          <div class="link">Preview the code</div>
+        </a>
       </div>
       
       <div class="art-card">
-        <iframe src="arts/floating_orb.html" title="CSS Cat Art"></iframe>
-        <p>Floating Orb by Kartikay</p>
+        <a href="art-viewer.html?file=floating_orb.html">
+          <iframe src="arts/floating_orb.html" title="CSS Cat Art"></iframe>
+          <p>Floating Orb by Kartikay</p>
+          <div class="link">Preview the code</div>
+        </a>
       </div>
       
       <div class="art-card">
-        <iframe src="arts/pulsating_ring.html" title="CSS Cat Art"></iframe>
-        <p>Pulsating Ring by Kartikay</p>
+        <a href="art-viewer.html?file=pulsating_ring.html">
+          <iframe src="arts/pulsating_ring.html" title="CSS Cat Art"></iframe>
+          <p>Pulsating Ring by Kartikay</p>
+          <div class="link">Preview the code</div>
+        </a>
       </div>
       
       <div class="art-card">
-        <iframe src="arts/waves.html" title="CSS Cat Art"></iframe>
-        <p>Waves by Kartikay</p>
+        <a href="art-viewer.html?file=waves.html">
+          <iframe src="arts/waves.html" title="CSS Cat Art"></iframe>
+          <p>Waves by Kartikay</p>
+          <div class="link">Preview the code</div>
+        </a>
       </div>
       
       <div class="art-card">
-        <iframe src="arts/neon-city.html" title="Neon City"></iframe>
-        <p>Neon City By Yashasvi</p>
+        <a href="art-viewer.html?file=neon-city.html">
+          <iframe src="arts/neon-city.html" title="Neon City"></iframe>
+          <p>Neon City By Yashasvi</p>
+          <div class="link">Preview the code</div>
+        </a>
       </div>
       
       <div class="art-card">
-        <iframe src="arts/manudwivedi-aurora.html" title="Aurora CSS Art (Interactive)"></iframe>
-        <p>Aurora by Manu Dwivedi</p>
-       </p>
+        <a href="art-viewer.html?file=manudwivedi-aurora.html">
+          <iframe src="arts/manudwivedi-aurora.html" title="Aurora CSS Art (Interactive)"></iframe>
+          <p>Aurora by Manu Dwivedi</p>
+          <div class="link">Preview the code</div>
+        </a>
       </div>
-     <!-- Contributors can add more art-cards here -->  
+      <!-- Contributors can add more art-cards here --> 
 
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
     </main>
     <footer>
       <p>Made with ❤️ by the Open Source Community | Hacktoberfest 2025</p>


### PR DESCRIPTION
Hi there!

This pull request resolves Issue #77 by fixing the inconsistent "Preview the code" buttons in the gallery.

**The Problem:**
As reported in the issue, many of the `art-card` elements in `index.html` did not have the necessary `<a>` tag structure to display the "Preview the code" link, leading to an inconsistent user experience.

**The Solution:**
I have gone through the `index.html` file and systematically updated all the inconsistent `art-card`s. Each one is now wrapped in the correct `<a>` tag, pointing to the `art-viewer.html` with the correct file parameter. This ensures that every art piece in the gallery now has a consistent preview link.

This should resolve the bug completely. Let me know if you'd like any changes!

Fixes #77